### PR TITLE
Swap to fork of omit-deep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "Base64": "~0.3.0",
     "lie": "~3.0.1",
     "lodash": "~4.3.0",
-    "omit-deep": "~0.1.2",
+    "omit-deep": "splodingsocks/omit-deep",
     "pouchdb": "~5.1.0",
     "sinon": "git+https://github.com/sinonjs/sinon.git"
   },

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -247,6 +247,24 @@ describe('FixtureHelper', ()=> {
 
         });
 
+        describe('with a valid JSON fixture requestBody containing an object nested in an array', ()=> {
+
+          beforeEach(() => {
+            fixture = { request: { body: '{"foo":"bar","bar":"foo","baz":{"bar":"foo", "bbb":[{"bar":"foo"}]}}' } };
+            fixtures = [fixture];
+            fixtureHelper.initialize({ omittedDataParams: ['bar'] });
+          });
+
+          describe('when the body matches with configured parameters omitted', ()=> {
+
+            it('returns an array containing the match', ()=> {
+              expect(fixtureHelper.find(fixtures, { requestBody: '{"foo":"bar","baz":{"bar":"kjndfkjbdf","bbb":[{"bar":"somethingelse"}]}}' })).to.eql([fixture]);
+            });
+
+          });
+
+        });
+
         describe('with an invalid JSON fixture requestBody', ()=> {
 
           beforeEach(()=> {


### PR DESCRIPTION
https://github.com/jonschlinkert/omit-deep/pull/1

If you've configured truman to omit a `foo` parameter, but your app is doing a POST request like this:

```
{
  booking: {
    upgrades: [{
      foo: <this changes>
    }]
  }
}
```

...the object within the array doesn't end up with the `foo` parameter omitted for comparison purposes, so you won't get a match.
