### PR TITLE
Fix fixture matching when paths and domain synonyms are combined

### DIFF
--- a/src/helpers/fixtures.js
+++ b/src/helpers/fixtures.js
@@ -50,10 +50,10 @@ let fixtureHelper = module.exports = {
         // so we exclude from the URL comparison and compare separately.
         const requestedUrl = options.url.split('?')[0];
         const fixtureUrl = fixture.request.url.split('?')[0];
-        const fixtureDomainSynonyms = fixtureHelper._config.domainSynonyms[fixtureUrl] || [];
+        const fixtureDomain = fixtureHelper.domainFromUrl(fixtureUrl);
+        const fixtureDomainSynonyms = fixtureHelper._config.domainSynonyms[fixtureDomain] || [];
 
-        const fixtureUrls = [fixtureUrl].concat(fixtureDomainSynonyms.map((domainSynonym) => fixtureUrl.replace(fixtureUrl, domainSynonym)));
-
+        const fixtureUrls = [fixtureUrl].concat(fixtureDomainSynonyms.map((domainSynonym) => fixtureUrl.replace(fixtureDomain, domainSynonym)));
         if (!_.includes(fixtureUrls, requestedUrl)) {
           return false;
         }
@@ -88,6 +88,17 @@ let fixtureHelper = module.exports = {
 
       return true;
     });
+  },
+
+  domainFromUrl(url) {
+    const protocol = url.split('/')[0];
+    const domain = url.split('/')[2];
+
+    if (!protocol || !domain) {
+      return null;
+    }
+
+    return `${protocol}//${domain}`;
   },
 
   findForSinonXHR(fixtures, xhr) {

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -147,7 +147,7 @@ describe('FixtureHelper', ()=> {
 
       beforeEach(()=> {
         fixtures = [
-          { request: { url: 'https://foo.com?bar=baz' } }
+          { request: { url: 'https://foo.com/bar/baz?bar=baz' } }
         ];
 
         fixtureHelper.initialize({ domainSynonyms: { 'https://foo.com': ['https://qux.com'] } });
@@ -156,15 +156,15 @@ describe('FixtureHelper', ()=> {
       describe('when the option matches a fixture', ()=> {
 
         it('returns an array containing the match', ()=> {
-          expect(fixtureHelper.find(fixtures, { url: 'https://foo.com?bar=baz' })).to.eql([{ request: { url: 'https://foo.com?bar=baz' } }]);
+          expect(fixtureHelper.find(fixtures, { url: 'https://foo.com/bar/baz?bar=baz' })).to.eql([{ request: { url: 'https://foo.com/bar/baz?bar=baz' } }]);
         });
 
       });
 
-      describe('when the option matches a domain synonym, which in turn matches a fixture', ()=> {
+      describe('when the option matches a domain synonym, which in turn matches a fixture with a path and some params', ()=> {
 
         it('returns an array containing the match', ()=> {
-          expect(fixtureHelper.find(fixtures, { url: 'https://qux.com?bar=baz' })).to.eql([{ request: { url: 'https://foo.com?bar=baz' } }]);
+          expect(fixtureHelper.find(fixtures, { url: 'https://qux.com/bar/baz?bar=baz' })).to.eql([{ request: { url: 'https://foo.com/bar/baz?bar=baz' } }]);
         });
 
       });


### PR DESCRIPTION
Currently, any request made to a domain synonym with a path will end up as a CALLTHROUGH, which effectively provides no fixtures. This reintroduces some behaviour ensuring the scope of the replacement for the domain synonym is limited to the domain part of the URL that seems to have been lost during a refactoring between v0.0.6 and v0.0.7.

Please don't review just yet, I'd like to see our application's whole selenium suite pass against a patched version of 0.0.7 before considering this good to go.
