### PR TITLE
Add levenshtein distance for ordered fixtures on mismatch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,6 +64,7 @@ gulp.task('connect', function() {
 
   return connect.server({
     root: 'sandbox',
+    port: 8081,
     livereload: true,
     middleware: function() {
       return [middleware];
@@ -74,7 +75,7 @@ gulp.task('connect', function() {
 gulp.task('open', function() {
   return gulp.src('./sandbox/index.html')
     .pipe(open({
-      uri: 'http://localhost:8080',
+      uri: 'http://localhost:8081',
       app: 'google chrome'
     }));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ gulp.task('connect', function() {
 
   return connect.server({
     root: 'sandbox',
-    port: 8081,
+    port: 8082,
     livereload: true,
     middleware: function() {
       return [middleware];
@@ -75,7 +75,7 @@ gulp.task('connect', function() {
 gulp.task('open', function() {
   return gulp.src('./sandbox/index.html')
     .pipe(open({
-      uri: 'http://localhost:8081',
+      uri: 'http://localhost:8082',
       app: 'google chrome'
     }));
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,8 @@ var customLaunchers = {
   win10chrome: { base: 'SauceLabs', browserName: 'chrome', platform: 'Windows 10' },
   win10firefox: { base: 'SauceLabs', browserName: 'firefox', platform: 'Windows 10' },
   win10ie11: { base: 'SauceLabs', browserName: 'internet explorer', platform: 'Windows 10' },
-  win7ie9: { base: 'SauceLabs', browserName: 'internet explorer', platform: 'Windows 7', version: '9.0' },
+  // Commented the below out for the time being as it's timing out a lot and failing builds randomly:
+  // win7ie9: { base: 'SauceLabs', browserName: 'internet explorer', platform: 'Windows 7', version: '9.0' },
   androidChrome: { base: 'SauceLabs', browserName: 'android', platform: 'Linux' },
   iosSafari: { base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10' },
   iosSafari92: { base: 'SauceLabs', browserName: 'iphone', platform: 'OS X 10.10', version: '9.2' }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chai": "~3.4.1",
     "del": "~2.2.0",
     "dirty-chai": "~1.2.2",
+    "fast-levenshtein": "^1.1.3",
     "gulp": "~3.9.0",
     "gulp-changed": "~1.3.0",
     "gulp-connect": "~2.3.1",

--- a/src/helpers/fixtures.js
+++ b/src/helpers/fixtures.js
@@ -1,8 +1,9 @@
 'use strict';
 
-let _ = require('lodash');
-let omitDeep = require('omit-deep');
-let xhrHelper = require('./xhr');
+const _ = require('lodash');
+const omitDeep = require('omit-deep');
+const xhrHelper = require('./xhr');
+const levenshtein = require('fast-levenshtein');
 
 let fixtureHelper = module.exports = {
   _config: {
@@ -87,6 +88,26 @@ let fixtureHelper = module.exports = {
       }
 
       return true;
+    });
+  },
+
+  sortByClosestMatchingURL(fixtures, xhr) {
+    // Sort sorts in place, which we don't want to do, so we clone the array.
+    fixtures = JSON.parse(JSON.stringify(fixtures));
+
+    return fixtures.sort(function(a, b) {
+      const aDistance = levenshtein.get(a.request.url, xhr.url);
+      const bDistance = levenshtein.get(b.request.url, xhr.url);
+
+      if (aDistance < bDistance) {
+        return -1;
+      }
+
+      if (aDistance > bDistance) {
+        return 1;
+      }
+
+      return 0;
     });
   },
 

--- a/src/truman.js
+++ b/src/truman.js
@@ -148,7 +148,13 @@ let truman = module.exports = {
             loggingHelper.log(xhr, fixture);
           } else {
             loggingHelper.log(`%cNOT FOUND%c: ${xhr.method} ${xhr.url}`, 'color: red', 'color: black');
-            loggingHelper.log(xhr, fixtures);
+            loggingHelper.log('Looking for XHR:', xhr);
+
+            if (xhr.method === 'GET') {
+              loggingHelper.log('Fixtures (closest URL first):', fixtureHelper.sortByClosestMatchingURL(fixtures, xhr));
+            } else {
+              loggingHelper.log('Fixtures:', fixtures);
+            }
           }
         });
 

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -35,7 +35,7 @@ describe('FixtureHelper', ()=> {
 
   describe('sortByClosestMatchingURL', () => {
 
-    let fixtures, xhr;
+    let fixtures;
 
     beforeEach(() => {
       fixtures = [

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -33,6 +33,40 @@ describe('FixtureHelper', ()=> {
 
   });
 
+  describe('sortByClosestMatchingURL', () => {
+
+    let fixtures, xhr;
+
+    beforeEach(() => {
+      fixtures = [
+        { request: { url: 'foo' } },
+        { request: { url: 'bar' } },
+        { request: { url: 'baz' } }
+      ];
+    });
+
+    it('sorts a set of fixtures according to the request URL', () => {
+      expect(fixtureHelper.sortByClosestMatchingURL(fixtures, { url: 'baz' })).to.eql([
+        { request: { url: 'baz' } },
+        { request: { url: 'bar' } },
+        { request: { url: 'foo' } }
+      ]);
+
+      expect(fixtureHelper.sortByClosestMatchingURL(fixtures, { url: 'bar' })).to.eql([
+        { request: { url: 'bar' } },
+        { request: { url: 'baz' } },
+        { request: { url: 'foo' } }
+      ]);
+
+      expect(fixtureHelper.sortByClosestMatchingURL(fixtures, { url: 'foo' })).to.eql([
+        { request: { url: 'foo' } },
+        { request: { url: 'bar' } },
+        { request: { url: 'baz' } }
+      ]);
+    });
+
+  });
+
   describe('addXhr(fixtures, xhr)', ()=> {
 
     let fixtures;


### PR DESCRIPTION
This makes debugging fixtures easier on `GET` requests by sorting the logged fixtures array (used for debugging) ordered with the most similar URL to the XHR request first.

We can do similar work for `POST` requests, but things will get a little more complex as we need to check the similarity between both the URL and the data payload - so this can be done as a separate PR.
