### PR TITLE
Ask for 50 MB of storage when truman is initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ truman.initialize([config])
 
 `initialize` returns a promise that resolves once initialization is complete.
 
+#### If using in Safari
+
+The default amount of storage Safari supplies to PouchDB [is quite low](https://pouchdb.com/errors.html#not_enough_space), and if exceeded a modal dialog will be opened that requires accepting. Truman will request 50 MB when it is initialized, with the aim of ensuring the dialog is opened at a predictable time (from the point of view of selenium you interact with it like an alert).
+
 ### record(fixtureCollectionName, [callback])
 ```javascript
 truman.record(fixtureCollectionName, [callback])

--- a/src/storage/adaptors/couchDB.js
+++ b/src/storage/adaptors/couchDB.js
@@ -17,7 +17,9 @@ let fixtureHelper = module.exports = {
   initialize(options) {
     _.assign(config, options);
     window.PouchDB = PouchDB; // Necessary for the PouchDB Chrome inspector
-    localDB = new PouchDB('truman');
+    localDB = new PouchDB('truman', {
+      size: 50
+    });
 
     if (config.database) {
       let remoteConfig = {


### PR DESCRIPTION
See the readme update.

Safari can open up a modal dialog if pouch uses more than a certain amount of space, if that happens during a selenium test it blocks all subsequent commands and generally derails any chance of it passing.

If we ask for more storage than we reasonably expect to use when initializing, the dialog still appears but at least we _know_ it's about to appear and can deal with it.
