### PR TITLE
Exclude omitted query params from existing fixtures when matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "~4.3.0",
     "omit-deep": "splodingsocks/omit-deep",
     "pouchdb": "~5.1.0",
-    "sinon": "git+https://github.com/sinonjs/sinon.git"
+    "sinon": "git+https://github.com/sinonjs/sinon.git#v2.0.0-pre"
   },
   "devDependencies": {
     "babel-core": "~6.4.0",

--- a/src/helpers/fixtures.js
+++ b/src/helpers/fixtures.js
@@ -60,7 +60,13 @@ let fixtureHelper = module.exports = {
         }
       }
 
-      if (options.query && !_.isEqual(options.query, fixture.request.query)) {
+      const filteredFixturedQuery = xhrHelper.getQueryStringObject({
+        url: 'http://localhost/?' + Object.keys(fixture.request.query || {}).map(function(key) {
+          return key + '=' + fixture.request.query[key];
+        }).join('&')
+      }, fixtureHelper._config.omittedQueryParams);
+
+      if (options.query && !_.isEqual(options.query, filteredFixturedQuery)) {
         return false;
       }
 

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -213,32 +213,52 @@ describe('FixtureHelper', ()=> {
 
     });
 
-    describe('when the query option is present', ()=> {
+    describe('when the query option is present', () => {
 
       let fixtures;
 
-      beforeEach(()=> {
-        fixtures = [
-          { request: { query: '?foo=bar' } }
-        ];
-      });
-
-      describe('when the option matches a fixture', ()=> {
-
-        it('returns an array containing the match', ()=> {
-          expect(fixtureHelper.find(fixtures, { query: '?foo=bar' })).to.eql([{ request: { query: '?foo=bar' } }]);
+      describe('and there are no omittedQueryParams', () => {
+        beforeEach(() => {
+          fixtures = [
+            { request: { query: {
+              foo: 'bar'
+            }}}
+          ];
         });
 
-      });
-
-      describe('when the option does not match a fixture', ()=> {
-
-        it('returns an empty array', ()=> {
-          expect(fixtureHelper.find(fixtures, { query: '?baz=qux' })).to.eql([]);
+        describe('when the option matches a fixture', () => {
+          it('returns an array containing the match', () => {
+            expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' }})).to.eql([{ request: { query: { foo: 'bar' } } }]);
+          });
         });
 
+        describe('when the option does not match a fixture', () => {
+          it('returns an empty array', () => {
+            expect(fixtureHelper.find(fixtures, { query: { baz: 'qux' }})).to.eql([]);
+          });
+        });
       });
 
+      // The input to this function already has the omitted params removed,
+      // and when the fixtures are recorded for the first time the omitted
+      // params are removed. This is effectively covering that if you were to
+      // omit a param and already had fixtures recorded containing the param,
+      // that they are still matched on a replay.
+      describe('and there are omittedQueryParams', () => {
+        beforeEach(() => {
+          fixtureHelper.initialize({ omittedQueryParams: ['bar'] });
+        });
+
+        it('excludes them from the fixture for the purposes of matching', () => {
+          fixtures = [
+            { request: { query: {
+              foo: 'bar',
+              bar: 'baz'
+            }}}
+          ];
+          expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' }})).to.eql([{ request: { query: { foo: 'bar', bar: 'baz' } }}]);
+        });
+      });
     });
 
     describe('when the requestBody option is present', ()=> {

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -219,22 +219,24 @@ describe('FixtureHelper', ()=> {
 
       describe('and there are no omittedQueryParams', () => {
         beforeEach(() => {
-          fixtures = [
-            { request: { query: {
-              foo: 'bar'
-            }}}
-          ];
+          fixtures = [{
+            request: {
+              query: {
+                foo: 'bar'
+              }
+            }
+          }];
         });
 
         describe('when the option matches a fixture', () => {
           it('returns an array containing the match', () => {
-            expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' }})).to.eql([{ request: { query: { foo: 'bar' } } }]);
+            expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' } })).to.eql([{ request: { query: { foo: 'bar' } } }]);
           });
         });
 
         describe('when the option does not match a fixture', () => {
           it('returns an empty array', () => {
-            expect(fixtureHelper.find(fixtures, { query: { baz: 'qux' }})).to.eql([]);
+            expect(fixtureHelper.find(fixtures, { query: { baz: 'qux' } })).to.eql([]);
           });
         });
       });
@@ -250,13 +252,15 @@ describe('FixtureHelper', ()=> {
         });
 
         it('excludes them from the fixture for the purposes of matching', () => {
-          fixtures = [
-            { request: { query: {
-              foo: 'bar',
-              bar: 'baz'
-            }}}
-          ];
-          expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' }})).to.eql([{ request: { query: { foo: 'bar', bar: 'baz' } }}]);
+          fixtures = [{
+            request: {
+              query: {
+                foo: 'bar',
+                bar: 'baz'
+              }
+            }
+          }];
+          expect(fixtureHelper.find(fixtures, { query: { foo: 'bar' } })).to.eql([{ request: { query: { foo: 'bar', bar: 'baz' } } }]);
         });
       });
     });


### PR DESCRIPTION
Say that you've already got a set of fixtures recorded, and want to add to the `omittedQueryParams` - for example something in a tracking-related param has changed and you don't want to re-record every fixture because the new param makes no difference to the API responses.

At the moment, omitted params are excluded from fixtures when they are recorded, and from the incoming requests as they are replayed - so adding this param to `omittedQueryParams` results in the incoming request (which for matching purposes now has the param omitted) not matching the recorded request and you have to re-record all the fixtures anyway.

I've omitted it from the recorded fixture _during replay mode as well_ to resolve this issue.

I've published this as a fork, `@shackpank/truman@0.1.0`, and it's tested internally on https://github.com/holidayextras/tripapplite/pull/4231 - there's also a new unit test and the existing ones have been modified to use more realistic data (the call site passes in an object, not a string, as the request query)
