### PR TITLE
Don't store fixtures for omittedDomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ const config = {
 
   // An array of remote domains (with scheme) for which you don't want to store or replay fixtures
   // This is typically useful for tracking calls that do not affect functionality of your app.
-  omittedDomains: ['https://my.trackingprovider.com'],
+  omittedDomains: [
+    'https://my.trackingprovider.com'
+  ],
 
   // Domain synonyms let us treat requests to one domain as matches for requests to another. For example, you
   // may record your fixtures against a local copy of an API but want to make sure those fixtures are replayed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ const config = {
   // An array request body JSON parameters to omit from XHR comparison when matching fixtures.
   omittedDataParams: ['requestid'],
 
+  // An array of remote domains (with scheme) for which you don't want to store or replay fixtures
+  // This is typically useful for tracking calls that do not affect functionality of your app.
+  omittedDomains: ['https://my.trackingprovider.com'],
+
   // Domain synonyms let us treat requests to one domain as matches for requests to another. For example, you
   // may record your fixtures against a local copy of an API but want to make sure those fixtures are replayed
   // when requests to the staging copy of the API are made during your test run. Domain synonyms do just that.
@@ -63,7 +67,7 @@ const config = {
 
     // Password for the remove CouchDB database.
     password: 'mycouchpassword'
-  }    
+  }
 }
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,12 +61,17 @@ gulp.task('connect', function () {
     { from: '^([^.]+[^/])$', to: '$1.html' }
   ])
 
+  const cors = function (req, res, next) {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    next()
+  }
+
   return connect.server({
     root: 'sandbox',
     port: 8082,
     livereload: true,
     middleware: function () {
-      return [middleware]
+      return [cors, middleware]
     }
   })
 })

--- a/src/truman.js
+++ b/src/truman.js
@@ -10,6 +10,9 @@ const storage = require('./storage')
 const Promise = require('lie')
 const _ = require('lodash')
 
+let opts = {
+  omittedDomains: []
+}
 let storageFixtures = []
 
 const RECORDING_STATE = 'recording'
@@ -22,6 +25,7 @@ const truman = module.exports = {
 
   initialize (options, callback) {
     const message = 'Truman is up and running!'
+    opts = _.assign(opts, options)
 
     if (truman._initialized) {
       if (callback) {
@@ -169,6 +173,11 @@ const truman = module.exports = {
               loggingHelper.log(fixtures)
             }
             return !foundFixtures // true = allow, false = stub
+          },
+          (method, url) => {
+            // For omitted domains we don't even want to log a CALLTHROUGH
+            const domain = fixtureHelper.domainFromUrl(url)
+            return _.includes(opts.omittedDomains, domain)
           }
         ]
 

--- a/src/truman.js
+++ b/src/truman.js
@@ -236,6 +236,11 @@ const truman = module.exports = {
   },
 
   _storeXHR (xhr, fixtureCollectionName) {
+    if (_.includes(opts.omittedDomains, fixtureHelper.domainFromUrl(xhr.url))) {
+      // Don't store fixtures for domains we don't care about
+      return
+    }
+
     loggingHelper.log(`%cRECORDING%c: ${xhr.url}`, 'color: red', 'color: black')
     fixtureHelper.addXhr(storageFixtures, xhr)
     xhr.fixtured = true


### PR DESCRIPTION
This PR ignores XHRs for domains configured by the consuming application. The main use case is to avoid bloating fixture databases with tracking calls that do not affect the running of the application. For one test of our application, the number of fixtures stored went from 591 to 119 just by omitting one domain.

This also greatly reduces noise in the browser console log when debugging.