### PR TITLE
No lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truman",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple test fixtures for single page apps",
   "main": "src/truman.js",
   "engine": "node >= 8.0.0",

--- a/src/helpers/fixtures.js
+++ b/src/helpers/fixtures.js
@@ -1,9 +1,19 @@
 'use strict'
 
-const _ = require('lodash')
+const findIndex = require('lodash/findIndex')
+const isEqual = require('lodash/isEqual')
+const filter = require('lodash/filter')
+const includes = require('lodash/includes')
 const omitDeep = require('omit-deep')
 const xhrHelper = require('./xhr')
 const levenshtein = require('fast-levenshtein')
+
+const _ = {
+  findIndex,
+  isEqual,
+  filter,
+  includes
+}
 
 const fixtureHelper = module.exports = {
   _config: {

--- a/src/helpers/fixtures.js
+++ b/src/helpers/fixtures.js
@@ -13,7 +13,7 @@ const fixtureHelper = module.exports = {
   },
 
   initialize (options) {
-    _.assign(fixtureHelper._config, options)
+    Object.assign(fixtureHelper._config, options)
   },
 
   addXhr (fixtures, xhr) {

--- a/src/helpers/state.js
+++ b/src/helpers/state.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const _ = require('lodash')
-
 const stateHelper = module.exports = {
 
   updateState (newState) {
@@ -10,7 +8,7 @@ const stateHelper = module.exports = {
     }
 
     const state = stateHelper.loadState()
-    window.localStorage.setItem('autoFixture', JSON.stringify(_.assign(state, newState)))
+    window.localStorage.setItem('autoFixture', JSON.stringify(Object.assign(state, newState)))
   },
 
   loadState () {

--- a/src/helpers/xhr.js
+++ b/src/helpers/xhr.js
@@ -1,7 +1,15 @@
 'use strict'
 
-const _ = require('lodash')
+const trim = require('lodash/trim')
+const omit = require('lodash/omit')
+const isEqual = require('lodash/isEqual')
 const RealXMLHttpRequest = window.XMLHttpRequest
+
+const _ = {
+  trim,
+  omit,
+  isEqual
+}
 
 module.exports = {
 

--- a/src/storage/adaptors/couchDB.js
+++ b/src/storage/adaptors/couchDB.js
@@ -16,7 +16,7 @@ let cachedRevisionMapping = null
 const fixtureHelper = module.exports = {
   initialize (options) {
 
-    _.assign(config, options)
+    Object.assign(config, options)
     window.PouchDB = PouchDB // Necessary for the PouchDB Chrome inspector
     localDB = new PouchDB('truman')
 

--- a/src/storage/adaptors/couchDB.js
+++ b/src/storage/adaptors/couchDB.js
@@ -2,7 +2,11 @@
 
 require('Base64')
 
-const _ = require('lodash')
+const includes = require('lodash/includes')
+const isArray = require('lodash/isArray')
+const compact = require('lodash/compact')
+const each = require('lodash/each')
+
 const PouchDB = require('pouchdb')
 
 const STORAGE_PREFIX = 'fixture-'
@@ -12,6 +16,13 @@ let config = {}
 let localDB = null
 let remoteDB = null
 let cachedRevisionMapping = null
+
+const _ = {
+  includes,
+  isArray,
+  compact,
+  each
+}
 
 const fixtureHelper = module.exports = {
   initialize (options) {

--- a/src/truman.js
+++ b/src/truman.js
@@ -8,7 +8,6 @@ const loggingHelper = require('./helpers/logging.js')
 const storage = require('./storage')
 
 const Promise = require('lie')
-const _ = require('lodash')
 
 let opts = {
   omittedDomains: []
@@ -25,7 +24,7 @@ const truman = module.exports = {
 
   initialize (options, callback) {
     const message = 'Truman is up and running!'
-    opts = _.assign(opts, options)
+    opts = Object.assign(opts, options)
 
     if (truman._initialized) {
       if (callback) {
@@ -150,7 +149,7 @@ const truman = module.exports = {
           (method, url) => {
             // For omitted domains we don't even want to log a CALLTHROUGH
             const domain = fixtureHelper.domainFromUrl(url)
-            return _.includes(opts.omittedDomains, domain)
+            return opts.omittedDomains.includes(domain)
           }
         ]
 
@@ -209,7 +208,7 @@ const truman = module.exports = {
   },
 
   _storeXHR (xhr, fixtureCollectionName) {
-    if (_.includes(opts.omittedDomains, fixtureHelper.domainFromUrl(xhr.url))) {
+    if (opts.omittedDomains.includes(xhr.url)) {
       // Don't store fixtures for domains we don't care about
       return
     }

--- a/test/unit/helpers/testFixtures.js
+++ b/test/unit/helpers/testFixtures.js
@@ -3,7 +3,6 @@
 const sinon = require('../../dependencies.js').sinon
 const expect = require('../../dependencies.js').expect
 
-const _ = require('lodash')
 const fixtureHelper = require('../../../src/helpers/fixtures.js')
 const xhrHelper = require('../../../src/helpers/xhr.js')
 
@@ -20,13 +19,9 @@ describe('FixtureHelper', () => {
   afterEach(() => sandbox.restore())
 
   describe('initialize(options)', () => {
-    beforeEach(() => {
-      sandbox.stub(_, 'assign')
-    })
-
     it('assigns the config to the module', () => {
       fixtureHelper.initialize({ foo: 'bar' })
-      expect(_.assign).to.have.been.calledWith(fixtureHelper._config, { foo: 'bar' })
+      expect(fixtureHelper._config).to.deep.include({ foo: 'bar' })
     })
   })
 


### PR DESCRIPTION
## Description
The very old version of webpack we use in truman has a bug where it globally exports a copy of lodash onto the window if it's required into your project anywhere in the style `const lodash = require('lodash')`. See https://github.com/webpack/webpack/issues/4465

This PR works around the issue by changing how we require in lodash to use the specific functions we need. This also has the side effect of shrinking the size of the truman bundle.

## Testing

To test this PR, you'll need to run a selenium test locally while using the copy of truman from your local repository.

* In this repo, `npm start`
* In the repo you're using as a test case (i.e. TripApp) alter the script reference to point at `http://localhost:8082/truman.min.js`
* Run your selenium test with `npm run selenium -- path/to/test.js`